### PR TITLE
feat: Add community files checklist feature 

### DIFF
--- a/app/client/src/components/FileChecklist/FileChecklist.tsx
+++ b/app/client/src/components/FileChecklist/FileChecklist.tsx
@@ -1,0 +1,53 @@
+import { CheckCircle2, XCircle } from "lucide-react"
+
+interface FileChecklistProps {
+    files: Array<{
+        name: string
+        exists: boolean
+    }>
+}
+
+const FileChecklist = ({ files }: FileChecklistProps) => {
+    const existingFiles = files.filter(f => f.exists)
+    const missingFiles = files.filter(f => !f.exists)
+
+    return (
+        <div className="border rounded-2xl p-6 space-y-4">
+            <h3 className="text-xl font-semibold">Community Guidelines Status</h3>
+            
+            {existingFiles.length > 0 && (
+                <div className="space-y-2">
+                    <h4 className="text-sm font-medium text-green-600 dark:text-green-400">
+                        ✓ Found ({existingFiles.length})
+                    </h4>
+                    <ul className="space-y-2">
+                        {existingFiles.map((file) => (
+                            <li key={file.name} className="flex items-center gap-2 text-sm">
+                                <CheckCircle2 className="w-4 h-4 text-green-600 dark:text-green-400" />
+                                <span>{file.name}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+
+            {missingFiles.length > 0 && (
+                <div className="space-y-2">
+                    <h4 className="text-sm font-medium text-red-600 dark:text-red-400">
+                        ✗ Missing ({missingFiles.length})
+                    </h4>
+                    <ul className="space-y-2">
+                        {missingFiles.map((file) => (
+                            <li key={file.name} className="flex items-center gap-2 text-sm opacity-60">
+                                <XCircle className="w-4 h-4 text-red-600 dark:text-red-400" />
+                                <span>{file.name}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    )
+}
+
+export default FileChecklist

--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -59,7 +59,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1342,7 +1341,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
       "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -1785,7 +1783,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2311,7 +2308,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -3354,7 +3350,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/app/server/src/routes/project.js
+++ b/app/server/src/routes/project.js
@@ -1,10 +1,10 @@
 import { Router } from 'express';
-import { scanProject, executeTask } from '../controllers/projectController.js';
+import { scanProject, executeTask, fetchCommunityFiles } from '../controllers/projectController.js';
 
 const router = Router();
 
 router.post('/scan', scanProject);
 router.post('/execute', executeTask);
+router.post('/fetch-files', fetchCommunityFiles);
 
 export default router;
-


### PR DESCRIPTION
## Description
Implements the feature requested in issue #10 to display repository community guideline files as a checklist.

## Changes Made
- Added `/fetch-files` API endpoint in backend to detect community guideline files
- Updated `GithubInput` component to call the API on button click
- Created `FileChecklist` component to display found/missing files with visual indicators
- Added loading state and error handling for better UX

## How to Test
1. Start the server and client
2. Enter a GitHub repository URL (e.g., `facebook/react`)
3. Click the arrow button
4. Verify the checklist shows which community files exist or are missing

## Screenshots
<img width="2104" height="1596" alt="image" src="https://github.com/user-attachments/assets/3f1b1ee2-25a3-4f45-9f88-1c7be6c4df48" />
<img width="2104" height="1596" alt="image" src="https://github.com/user-attachments/assets/14dd94e1-cd26-4ecd-90b5-0ccee5578e47" />


Closes #10 